### PR TITLE
Remember the last used notebook and automatically focus the URL input

### DIFF
--- a/lib/web-clipper-message-dialog.js
+++ b/lib/web-clipper-message-dialog.js
@@ -10,6 +10,7 @@ const { Note } = models
 
 export default class WebClipperMessageDialog extends React.Component {
   dialog = { dismissDialog: () => null }
+  urlInput = null
   state = {
     urlToClip: '',
     destBookId: null,
@@ -73,6 +74,7 @@ export default class WebClipperMessageDialog extends React.Component {
           </div>
           <div className="field">
             <input
+              ref={i => (this.urlInput = i)}
               type="text"
               value={this.state.urlToClip}
               onChange={this.handleChangeUrl}
@@ -85,6 +87,8 @@ export default class WebClipperMessageDialog extends React.Component {
   }
 
   handleChangeBook = bookId => {
+    // Remember the selected notebook so we can default to it next time.
+    inkdrop.config.set('web-clipper.defaultNotebook', bookId);
     this.setState({
       destBookId: bookId
     })
@@ -172,10 +176,13 @@ Clipped from [${
     if (!this.dialog.isShown) {
       this.setState({
         urlToClip: '',
-        destBookId: null,
+        destBookId: inkdrop.config.get('web-clipper.defaultNotebook'),
         formErrorMessage: null
       })
       this.dialog.showDialog()
+
+      // Automatically focus the URL field so the user can directly paste a URL.
+      this.urlInput.focus()
     }
   }
 }


### PR DESCRIPTION
This improves usability for the case of usually clipping to the same notebook (1 click instead of 4), and slightly improves the case of saving to different notebooks every time (3 instead of 4 clicks).